### PR TITLE
use upath

### DIFF
--- a/data_pipelines/assets/flood/discharge.py
+++ b/data_pipelines/assets/flood/discharge.py
@@ -69,7 +69,7 @@ def raw_discharge(context: AssetExecutionContext, cds_client: CDSClient) -> None
         "product_type": product_type,
     }
 
-    out_path = get_path_in_asset(context, settings.base_data_path, ".grib")
+    out_path = get_path_in_asset(context, settings.base_data_upath, ".grib")
     out_path.mkdir(parents=True, exist_ok=True)
     cds_client.fetch_data(request_params, out_path)
 

--- a/data_pipelines/assets/flood/upstream.py
+++ b/data_pipelines/assets/flood/upstream.py
@@ -11,7 +11,7 @@ from data_pipelines.utils.flood.config import UPSTREAM_URL
 
 @asset(key_prefix=["flood"], io_manager_key="netcdf_io_manager")
 def uparea_glofas_v4_0(context: AssetExecutionContext) -> None:
-    out_path = get_path_in_asset(context, settings.base_data_path, ".nc")
+    out_path = get_path_in_asset(context, settings.base_data_upath, ".nc")
     out_path.mkdir(parents=True, exist_ok=True)
 
     response = httpx.get(UPSTREAM_URL)


### PR DESCRIPTION
`get_path_in_asset` should receive the base data path as a `UPath` not a `string`