### PR TITLE
fix: pyarrow error

### DIFF
--- a/data_pipelines/assets/flood/discharge.py
+++ b/data_pipelines/assets/flood/discharge.py
@@ -1,4 +1,3 @@
-import os
 from datetime import datetime, timedelta
 
 import dask.dataframe as dd
@@ -183,6 +182,9 @@ def detailed_forecast(
     detailed_forecast_df = add_geometry(
         detailed_forecast_df, GLOFAS_RESOLUTION / 2, GLOFAS_PRECISION
     )
+
+    detailed_forecast_df["issued_on"] = detailed_forecast_df["issued_on"].astype(str)
+    detailed_forecast_df["valid_for"] = detailed_forecast_df["valid_for"].astype(str)
 
     return detailed_forecast_df
 


### PR DESCRIPTION
An error occurs complaining about the type of columns `issued_on` and `valid_for`. Specifically, they are of type `datetime.date`. Using `str` fixes this