### PR TITLE
fix: glofas resource only needs to download

### DIFF
--- a/data_pipelines/resources/glofas_resource.py
+++ b/data_pipelines/resources/glofas_resource.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 import cdsapi
 import fsspec
@@ -24,11 +25,4 @@ class CDSClient(ConfigurableResource):
         self._client = cdsapi.Client(url=self.api_url, key=self._user_key)
 
     def fetch_data(self, request_params, output_path: UPath):
-        cached_output_path = fsspec.open_local(
-            f"simplecache::{output_path}",
-            filecache={"cache_storage": settings.fsspec_cache_storage},
-            **output_path.storage_options,
-        )
-        self._client.retrieve(
-            "cems-glofas-forecast", request_params, cached_output_path
-        )
+        self._client.retrieve("cems-glofas-forecast", request_params, output_path)


### PR DESCRIPTION
The glofas resource only needs to download the data to the AWS bucket. Using `fsspec.open_local` to cache the files is taken care of by the `GribDischargeIOManager` in `io_managers.py`