### PR TITLE
fix: add dagster.yaml file to the dagster_home folder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,3 +10,4 @@ RUN poetry install --without dev
 
 ENV DAGSTER_HOME=/opt/dagster/dagster_home/
 COPY data_pipelines/ /opt/dagster/app/data_pipelines/
+COPY dagster.yaml ${DAGSTER_HOME}


### PR DESCRIPTION
Add the `dagster.yaml` file to the `DAGSTER_HOME` folder so that the concurrency limit tag can be used in the code.