### PR TITLE
fix: write GRIB to local

### DIFF
--- a/data_pipelines/assets/flood/discharge.py
+++ b/data_pipelines/assets/flood/discharge.py
@@ -4,6 +4,7 @@ import dask.dataframe as dd
 import pandas as pd
 import xarray as xr
 from dagster import AssetExecutionContext, AssetIn, asset
+from upath import UPath
 
 from data_pipelines.partitions import discharge_partitions
 from data_pipelines.resources.dask_resource import DaskResource
@@ -68,8 +69,8 @@ def raw_discharge(context: AssetExecutionContext, cds_client: CDSClient) -> None
         "product_type": product_type,
     }
 
-    out_path = get_path_in_asset(context, settings.base_data_upath, ".grib")
-    out_path.mkdir(parents=True, exist_ok=True)
+    out_path = get_path_in_asset(context, UPath(settings.fsspec_cache_storage), ".grib")
+    out_path.parent.mkdir(parents=True, exist_ok=True)
     cds_client.fetch_data(request_params, out_path)
 
 


### PR DESCRIPTION
Write GRIB files to the local file system because the `cdsapi` library can't write to a remote location. 