### PR TITLE
fix: add eccodes library system dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.11.6-slim
 
 RUN mkdir -p /opt/dagster/dagster_home /opt/dagster/app
+RUN apt-get update && apt-get install -y libeccodes-tools
 
 ENV POETRY_VIRTUALENVS_CREATE=false
 WORKDIR /opt/dagster/app


### PR DESCRIPTION
The `ecCodes` library, developed by ECMWF (European Centre for Medium-Range Weather Forecasts) and used to open GRIB files, has system level dependencies.