### PR TITLE
fix: use tag concurrency limits in deployment

### DIFF
--- a/deployment/dagster/values.yaml
+++ b/deployment/dagster/values.yaml
@@ -48,6 +48,9 @@ dagsterDaemon:
     config:
       queuedRunCoordinator:
         maxConcurrentRuns: 3
+        tagConcurrencyLimits:
+        - key: "sequential_backfill"
+          limit: 1
 
 
 runLauncher:


### PR DESCRIPTION
Defining the tag concurrency limits in the `dagster.yaml` file doesn't work when deploying. This fix should solve the issue by adding it to the `values.yaml` file in the deployment folder.