### PR TITLE
fix: don't use dask resource

### DIFF
--- a/data_pipelines/assets/flood/discharge.py
+++ b/data_pipelines/assets/flood/discharge.py
@@ -85,7 +85,6 @@ def raw_discharge(context: AssetExecutionContext, cds_client: CDSClient) -> None
 )
 def transformed_discharge(
     context: AssetExecutionContext,
-    dask_resource: DaskResource,
     raw_discharge: xr.Dataset,
     uparea_glofas_v4_0: xr.Dataset,
 ) -> pd.DataFrame:


### PR DESCRIPTION
Using dask for the transformed discharge asset introduces two issues:
- As things are currently setup with multiple partitions for the asset, a new dask cluster would have to be spun up for each of the 30 partitions.
- The discharge grib files from the upstream asset would have to be persisted to the S3 bucket, instead of just being written to the node's "tmp" directory.

A better solution has to exist...