### PR TITLE
fix: move grib data to S3 and read from it

### DIFF
--- a/data_pipelines/assets/flood/discharge.py
+++ b/data_pipelines/assets/flood/discharge.py
@@ -8,7 +8,10 @@ from dagster import AssetExecutionContext, AssetIn, asset
 from data_pipelines.partitions import discharge_partitions
 from data_pipelines.resources.dask_resource import DaskResource
 from data_pipelines.resources.glofas_resource import CDSClient
-from data_pipelines.resources.io_managers import get_path_in_asset
+from data_pipelines.resources.io_managers import (
+    copy_local_file_to_s3,
+    get_path_in_asset,
+)
 from data_pipelines.settings import settings
 from data_pipelines.utils.flood.config import *
 from data_pipelines.utils.flood.filter_by_upstream import apply_upstream_threshold
@@ -71,6 +74,9 @@ def raw_discharge(context: AssetExecutionContext, cds_client: CDSClient) -> None
     out_path = get_path_in_asset(context, settings.tmp_storage, ".grib")
     out_path.parent.mkdir(parents=True, exist_ok=True)
     cds_client.fetch_data(request_params, out_path)
+    target_path = get_path_in_asset(context, settings.base_data_upath, ".grib")
+    target_path.mkdir(parents=True, exist_ok=True)
+    copy_local_file_to_s3(out_path, target_path)
 
 
 @asset(

--- a/data_pipelines/resources/__init__.py
+++ b/data_pipelines/resources/__init__.py
@@ -27,6 +27,6 @@ RESOURCES = {
     "cds_client": CDSClient(
         user_id=EnvVar("CDS_USER_ID"), api_key=EnvVar("CDS_API_KEY")
     ),
-    "grib_io_manager": GribDischargeIOManager(base_path=settings.tmp_storage),
+    "grib_io_manager": GribDischargeIOManager(base_path=settings.base_data_upath),
     "netcdf_io_manager": NetdCDFIOManager(base_path=settings.base_data_upath),
 }


### PR DESCRIPTION
Use S3 bucket with GRIB data and caching to test the running of transformed discharge using Dask cluster