### PR TITLE
fix: add automatic retry of failed jobs with linear backoff

### DIFF
--- a/data_pipelines/jobs.py
+++ b/data_pipelines/jobs.py
@@ -1,4 +1,15 @@
-from dagster import MAX_RUNTIME_SECONDS_TAG, ScheduleDefinition, define_asset_job
+from dagster import (
+    MAX_RUNTIME_SECONDS_TAG,
+    ScheduleDefinition,
+    RetryPolicy,
+    Backoff,
+    define_asset_job,
+)
+
+# makes job retry with linear backoff. With these settings, the last retry is
+# after 7500 seconds (125 minutes)
+retry_policy = RetryPolicy(max_retries=5, delay=500, backoff=Backoff.LINEAR)
+
 
 # build a job that materializes all flood assets
 # should timeout after 1 hour
@@ -6,6 +17,7 @@ all_flood_assets_job = define_asset_job(
     "all_flood_assets_job",
     selection="flood/raw_discharge*",
     tags={MAX_RUNTIME_SECONDS_TAG: 43000},
+    op_retry_policy=retry_policy,
 )
 
 # define a schedule that runs the all_assets_job every day at 09:30 UTC


### PR DESCRIPTION
Adds automatic retry of jobs if they fail.
It does so with linear backoff. So the first time it waits 500 seconds, the second time 1000 seconds, and so on.