### PR TITLE
fix: add dagster-cds-key secret

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ COPY pyproject.toml poetry.lock /opt/dagster/app/
 # as they make building on arm macs crash.
 RUN poetry config --local installer.no-binary rasterio,fiona
 
-RUN poetry install --without dev
+RUN poetry install --without dev --no-root
 
 ENV DAGSTER_HOME=/opt/dagster/dagster_home/
 COPY data_pipelines/ /opt/dagster/app/data_pipelines/

--- a/deployment/dagster/values.yaml
+++ b/deployment/dagster/values.yaml
@@ -12,6 +12,7 @@ dagster-user-deployments:
       port: 3030
       envSecrets:
         - name: "dagster-aws-credentials"
+        - name: "dagster-cds-key"
       envConfigMaps:
         - name: "dagster-config"
 
@@ -70,6 +71,7 @@ runLauncher:
           ttlSecondsAfterFinished: 7200
       envSecrets:
         - name: "dagster-aws-credentials"
+        - name: "dagster-cds-key"
       envConfigMaps:
         - name: "dagster-config"
 


### PR DESCRIPTION
These changes loads the new dagster-cds-key secret, so it can be stored as a kubernetes secret instead of in ConfigMap.

Depends on: https://github.com/openearthplatforminitiative/infrastructure/pull/68
